### PR TITLE
Silence error output - small cosmetical fix

### DIFF
--- a/xruncounter.c
+++ b/xruncounter.c
@@ -275,7 +275,7 @@ sys_info()
     }
     fp = NULL;
 
-    fp = popen("pactl list short modules | grep jack-", "r");
+    fp = popen("pactl list short modules 2>/dev/null | grep jack-", "r");
     printf("\n********************** Pulseaudio **********************\n\n");
     if (fp == NULL) {
         printf("    pulse isn't installed?\n" );


### PR DESCRIPTION
In case of PipeWire there is abstraction to be compatible with pulseaudio daemon but the command itself doesn't exist.

This small fix silences standard error but the check is still working.

Makes output prettier.